### PR TITLE
Update installation instructions, fix merge sort info message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help:
 	@echo "  - After pushing to github, this will be the official website"
 
 website:
+	npm install
 	npx webpack --config webpack.config.js
 
 deploy: website

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ This library is inspired by [David Galles' Javascript visualisations](https://ww
 The only external dependency is the [SVG.js library](https://svgjs.dev/), it is included in the `lib` directory.
 
 The code has been migrated to TypeScript, and it uses Webpack. To compile it you run `make website`, and then a website is created in the folder `public/`. To publish on Github, you run `make deploy` and push the changes.
+
+If you do not have `make`, you first have to run `npm install` to install all dependencies, and then you can compile the code into the `public/` folder using `npx webpack --config webpack.config.js`.

--- a/src/sorting/MergeSort.ts
+++ b/src/sorting/MergeSort.ts
@@ -8,7 +8,7 @@ import { RecursiveSortingGeneralControls } from "~/general-controls/recursive-so
 
 export const MergeSortMessages = {
     sort: {
-        split: (a: string, b: string) => `Split ${a} from ${b}`,
+        split: (direction: 'left' | 'right') => `Recursively sort ${direction} subarray`,
         merge: `Merge subarrays`,
         move: (a: string) => `Move ${a} to upper array`,
         foundNewMin: (a: string) => `Found a smaller value ${a}`,
@@ -85,9 +85,8 @@ export class MergeSort extends BaseSorter implements Sorter {
                     this.setViewBoxCenter(arr.cx(), arr.cy(), true)
                                 
                 await this.pause(
-                    "merge.split",
-                    leftSubArr.getValues(),
-                    arr.getValues()
+                    "sort.split",
+                    "left"
                 );
                 
                 // Sort left subarray recursively
@@ -121,9 +120,8 @@ export class MergeSort extends BaseSorter implements Sorter {
                     .dy(rightSubArrDeltaMove.y);
                                 
                 await this.pause(
-                    "merge.split",
-                    rightSubArr.getValues(),
-                    arr.getValues()
+                    "sort.split",
+                    "right"
                 );
 
                 // Sort right subarray recursively


### PR DESCRIPTION
Update Makefile to automatically install dependencies, and add instructions for how to compile the website without using `make`.

Also fix a information message for one of the steps in merge sort to be less cluttered.